### PR TITLE
[feature] 에디터 동영상 처리 유틸 구현

### DIFF
--- a/.changeset/spicy-weeks-jog.md
+++ b/.changeset/spicy-weeks-jog.md
@@ -1,0 +1,5 @@
+---
+"@byuckchon-frontend/utils": minor
+---
+
+add: editor 관련 util

--- a/src/packages/utils/src/editor/index.ts
+++ b/src/packages/utils/src/editor/index.ts
@@ -1,0 +1,38 @@
+export const iframeHTMLRenderer = {
+    htmlBlock: {
+      iframe(node: { attrs: Record<string, string>; childrenHTML: string }) {
+        return [
+          {
+            type: 'openTag',
+            tagName: 'iframe',
+            outerNewLine: true,
+            attributes: node.attrs,
+          },
+          { type: 'html', content: node.childrenHTML ?? '' },
+          { type: 'closeTag', tagName: 'iframe', outerNewLine: true },
+        ];
+      },
+    },
+};
+
+export const convertVideoLinks = (html: string) => {
+    let converted = html;
+    const createIframe = (src: string) =>
+      `<iframe src="${src}" frameborder="0" allowfullscreen style="display:block;width:100%;max-width:100%;aspect-ratio:16 / 9;height:auto;"></iframe>`;
+  
+    converted = converted.replace(
+      /https?:\/\/youtu\.be\/([a-zA-Z0-9_-]+)/g,
+      (_, id) => createIframe(`https://www.youtube.com/embed/${id}`),
+    );
+  
+    converted = converted.replace(
+      /https?:\/\/www\.youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/g,
+      (_, id) => createIframe(`https://www.youtube.com/embed/${id}`),
+    );
+  
+    return converted;
+};
+  
+
+
+  

--- a/src/packages/utils/src/index.ts
+++ b/src/packages/utils/src/index.ts
@@ -5,3 +5,4 @@ export * from "./filterParams";
 export * from "./userAgent";
 export * from "./sanitizeHtml";
 export * as dateUtils from "./DateUtils";
+export * as editorUtils from "./editor";


### PR DESCRIPTION
## ✨ 작업 내용

- 에디터 동영상 처리 유틸 구현
- iframeHTMLRenderer : Toast Editor preview 영역에서 iframe 태그가 정상적으로 렌더링되도록 처리
   - Viewer에서도 선택적으로 사용 가능
- convertVideoLinks : 유튜브 링크를 iframe 형태로 변환하여 에디터에서 영상이 바로 표시되도록 처리


## 사용예시
https://www.notion.so/editorUtils-32c2894cd58380698bd8fe90f43c4c22?source=copy_link